### PR TITLE
Fix segfault caused by misspelled(?) font name.

### DIFF
--- a/demo.cpp
+++ b/demo.cpp
@@ -8,6 +8,7 @@
 
 #include "label.hpp"
 #include <glfw3.h>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/transform.hpp>
 #include <codecvt>
 #include <iomanip>

--- a/label.cpp
+++ b/label.cpp
@@ -362,7 +362,7 @@ FT_Face GLFontManager::GetDefaultFont()
 {
 	// TODO
 	if(!defaultFace)
-		defaultFace = GLFontManager::GetFontFromPath("/usr/share/fonts/noto/NotoSans-Regular.ttc");
+		defaultFace = GLFontManager::GetFontFromPath("/usr/share/fonts/noto/NotoSans-Regular.ttf");
 	return defaultFace;
 }
 


### PR DESCRIPTION
Also fixes an error where GLM refuses to compile due to use of an experimental feature.

I'm still getting a gray screen on Arch Linux with an Intel GPU, though. Looking into that.