### PR TITLE
Fixed the Vertex Attribute being cast to float.

### DIFF
--- a/lib/gllabel.cpp
+++ b/lib/gllabel.cpp
@@ -236,7 +236,7 @@ void GLLabel::Render(float time, glm::mat4 transform)
 	glEnableVertexAttribArray(1);
 	glEnableVertexAttribArray(2);
 	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, pos));
-	glVertexAttribPointer(1, 1, GL_UNSIGNED_INT, GL_FALSE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, data));
+	glVertexAttribIPointer(1, 1, GL_UNSIGNED_INT, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, data));
 	glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, color));
 
 	glDrawArrays(GL_TRIANGLES, 0, this->verts.size());
@@ -281,7 +281,7 @@ void GLLabel::Render(float time, glm::mat4 transform)
 
 		glBindBuffer(GL_ARRAY_BUFFER, this->caretBuffer);
 		glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, pos));
-		glVertexAttribPointer(1, 1, GL_UNSIGNED_INT, GL_FALSE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, data));
+		glVertexAttribIPointer(1, 1, GL_UNSIGNED_INT, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, data));
 		glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(GLLabel::GlyphVertex), (void*)offsetof(GLLabel::GlyphVertex, color));
 
 		glBufferData(GL_ARRAY_BUFFER, 6 * sizeof(GlyphVertex), &x[0], GL_STREAM_DRAW);


### PR DESCRIPTION
Developing on Ubuntu 20.10 with x86_64 CPU and NVIDIA Graphics Card.
The data portion of the glyph vertex shader was being cast
to a float when using `glVertexAttribPointer()` call. Changed call
to `glVertexAttribIPointer()` to prevent this cast and leave the
integer intact.

Before the fix, none of the glyphs were visible. When I build now, the glyphs are visible.